### PR TITLE
fix：警告画面のデザイン修正

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.8.2"
+        "react-router-dom": "^7.8.2",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -3289,6 +3290,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/frontend/src/components/study/StudyTracker.tsx
+++ b/frontend/src/components/study/StudyTracker.tsx
@@ -3,6 +3,9 @@ import { Clock, Play, Pause, Square, Plus, Trophy } from 'lucide-react';
 import Button from '../ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
 import { useAppContext } from '../../contexts/AppContext';
+// NEW: 追加
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 export default function StudyTracker() {
   const { user, studySessions, addStudySession } = useAppContext();
@@ -16,7 +19,7 @@ export default function StudyTracker() {
     let interval: NodeJS.Timeout;
     if (isRunning) {
       interval = setInterval(() => {
-        setTime(time => time + 1);
+        setTime((time) => time + 1);
       }, 1000);
     }
     return () => clearInterval(interval);
@@ -24,7 +27,12 @@ export default function StudyTracker() {
 
   const handleStart = () => {
     if (!subject) {
-      alert('勉強科目を選択してください！');
+      // CHANGED: alert -> toast.warn
+      toast.warn('勉強科目を選択してください！', {
+        position: 'top-center',
+        autoClose: 3000, //アラートが閉じるまでの時間
+        theme: 'colored',
+      });
       return;
     }
     setIsRunning(true);
@@ -38,7 +46,7 @@ export default function StudyTracker() {
     if (time > 0) {
       const hours = Math.floor(time / 3600);
       const minutes = Math.floor((time % 3600) / 60);
-      const duration = hours + (minutes / 60);
+      const duration = hours + minutes / 60;
       const betCoinsEarned = Math.floor(duration * 100);
 
       addStudySession({
@@ -49,9 +57,25 @@ export default function StudyTracker() {
         betCoinsEarned,
       });
 
-      alert(`お疲れ様でした！\n${Math.floor(duration * 100) / 100}時間勉強して${betCoinsEarned}ベットコインを獲得しました！`);
+      // CHANGED: alert -> toast.success
+      toast.info(
+        `お疲れ様でした！\n${Math.floor(duration * 100) / 100}時間勉強して${betCoinsEarned}ベットコインを獲得しました！`,
+        {
+          position: 'top-center',
+          autoClose: 3500,
+          theme: 'colored',
+          // icon を少しリッチに
+          icon: '🏁',
+        }
+      );
+    } else {
+      // NEW: 0秒で終了した時の案内
+      toast.error('タイマーが0秒です。記録は追加されません。', {
+        position: 'top-center',
+        autoClose: 2000,
+      });
     }
-    
+
     setIsRunning(false);
     setTime(0);
     setSubject('');
@@ -59,10 +83,11 @@ export default function StudyTracker() {
 
   const handleAddSubject = () => {
     if (newSubject.trim() && user) {
-      // In a real app, this would update the user's subjects
       setSubject(newSubject);
       setNewSubject('');
       setShowNewSubjectInput(false);
+      // OPTIONAL: 追加トースト
+      toast.success('科目を追加しました', { autoClose: 1500 });
     }
   };
 
@@ -70,13 +95,18 @@ export default function StudyTracker() {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
     const secs = seconds % 60;
-    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    return `${hours.toString().padStart(2, '0')}:${minutes
+      .toString()
+      .padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
   };
 
   if (!user) return null;
 
   return (
     <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* NEW: ここに置く or App.tsx で全体に1回だけ置く */}
+      <ToastContainer position="top-center" theme="colored" />
+
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">勉強記録</h1>
         <p className="text-gray-600">時間を計測してベットコインを稼ごう！</p>


### PR DESCRIPTION
# 警告画面のデザイン修正
## 変更内容
- toastを使って警告の表示の修正

## スコープ範囲外
- レース画面のベット最終確認でも同様の警告が表示されたが、そもそも警告が適切なデザインでないと判断
<img width="812" height="848" alt="スクリーンショット 2025-09-09 16 13 16" src="https://github.com/user-attachments/assets/e592d513-d1e3-4c76-9bc7-75026d7e5af0" />

## 今後の展望
- 勉強記録をDBに保持する流れの実装
- 別途最終確認の警告デザインの作成
<img width="931" height="459" alt="スクリーンショット 2025-09-09 16 16 11" src="https://github.com/user-attachments/assets/0dcb2a09-b28f-4274-9798-710dd4b1e217" />
