### PR TITLE
Feature/past race result

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -513,7 +513,8 @@ export default function Dashboard() {
               </div>
             ) : (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* ▼左：順位表（全体クリックで遷移・1位差は表示しない） */}
+                {/* ▼ベット参加時（user.inRace === false） */}
+                {/* 左：順位表（全体クリックで遷移・1位差は表示しない） */}
                 <Link
                   to={`/races/${race?.id}`}
                   className="md:col-span-2 block rounded-xl border border-gray-100 p-4 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-300"
@@ -532,8 +533,7 @@ export default function Dashboard() {
                     ) : participants.length === 0 ? (
                       <li className="py-2 text-sm text-gray-500">参加者がまだいません</li>
                     ) : (
-                      // ★ ここがポイント：slice(0,3)は不要
-                      participants.map((p, i) => {
+                      participants.slice(0, 3).map((p, i) => {
                         const rank = i + 1; // 配列順 = 順位
                         const rankStyle =
                           rank === 1
@@ -545,7 +545,10 @@ export default function Dashboard() {
                         return (
                           <li
                             key={p.id}
-                            className={`flex items-center justify-between rounded-lg border px-3 py-2.5 ${rankStyle}`}
+                            className={[
+                              "flex items-center justify-between rounded-lg border px-3 py-2.5",
+                              rankStyle,
+                            ].join(" ")}
                           >
                             <div className="flex items-center gap-3 min-w-0">
                               <span className="w-8 text-right tabular-nums text-gray-500">

--- a/frontend/src/components/race/RaceScreen.tsx
+++ b/frontend/src/components/race/RaceScreen.tsx
@@ -572,7 +572,6 @@ export default function RaceScreen() {
                   <span className="font-semibold">{selectedRace.name}</span>
                   <span className="mx-2">｜</span>
                   <span>期間: {formatActivePeriod()}</span>
-                  <span className="mx-2">｜</span>
                 </div>
 
                 {/* 簡易順位表 */}

--- a/frontend/src/utils/getParticipantsFromRaceId.ts
+++ b/frontend/src/utils/getParticipantsFromRaceId.ts
@@ -30,7 +30,5 @@ export const getParticipantsFromRaceId = async (raceId: string): Promise<UserPri
     currentWeekStudyTime: p.users.current_week_study_time || 0,
   } as UserPrivate));
 
-  // 上位3名だけにする場合は以下を有効化
-  return mapped.slice(0, 3);
-  // return mapped;
+  return mapped;
 };


### PR DESCRIPTION
#過去のレース結果表示と問題修正
## 変更内容
- 順位表が映らないバグの修正
- 過去のレース結果UIの作成
- 順位表の色付け

## スコープ範囲外
- 過去レース結果の情報抽出
→DBの作成がいる

## 今後の展望
- レース結果を保存するDBの作成
- オッズを保存するDBの作成

<img width="947" height="834" alt="スクリーンショット 2025-09-12 21 52 28" src="https://github.com/user-attachments/assets/045071e0-64fa-4def-aba7-36e84a65fb2c" />
<img width="946" height="610" alt="スクリーンショット 2025-09-12 21 52 43" src="https://github.com/user-attachments/assets/0e7033c8-2870-478d-8deb-b8db9ef01d4d" />

